### PR TITLE
Check lang keys at compile time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ deploy:
   skip_cleanup: true
   prerelease: true
   api_key:
-    secure: EDe3KykJ7BGwnIlsdiZGUVU0qev5uHd+3V5aq5be2VQYpvBIS1Ifh+MjMfLSs4DuViT9TbBXqMwRdj9Ub5CAK2uSTsCxBXC6me9ozyrX326l2EawCTbPqKwBpy3lQeKyvwb4XJJ5U5ugvzqRX0WYfdM1/n+77Tu14YIqIpyKJNruNAhZyBhnvuaQ/EfVWl/eWhXHAa51GklWq3xsIJHG991wZ7dMZsooETfSTzX0ZK3JaI0dZsgTZMsBIDJePOcdoCzSsdBCq/yQVMT4GLEDq6rFp46gGix6H3QEm4wc16w70ksX8iJgbhrHp1OZVsDAZw3Nc94BIuaJqFJbl3itRIayM5IS3sd4TIjBc8X8dVJOh+wrObL6j8EmWkfi84KedFQKQ6UYZLjy4Aaki6oqCn6JMsa73+g0r0UrTeIMt0hcyVQDwzRFd+iyKr4c+hsvGUFZAxU5h+2aMrp2PnEp7UKr0ljQZZ1zVONwBj3PrBaDbvHBl7AOFlfAkZxobbqrvjgq3p5G8BXENmyPnrfPNxByxxDsu2SpagZLOQOLrz3fXnv9SjMjL2/QrpLGmIVAOG7lPD7x5YgeGJHKJKvE/HijQcQCpdXmh4KlGH4Hpeq1JYf1ledK2cYHnzFltcCuoVscTf8i35pghmwD9yDDEIund08cIyq+6e4NEC+/r/g=
+    secure: ${GITHUB_DEPLOY_KEY}
   file: './nyaautils-$TRAVIS_BRANCH-v$main_version.$TRAVIS_BUILD_NUMBER.jar'
   on:
     tags: false
@@ -41,5 +41,4 @@ branches:
   - "maven-repo"
 env:
   global:
-    - secure: d87YXY8y4KW9v06Q4VmkEyUVPgfjGu334jcNhllfRdMQub9ue0ofSP1XR41bCMwcWvPyMuauIsSS6wA5TojeWTAFXV9ESzWHonLhCJpMcTL/8+Ohc62qQZCpWWWqze5wBgh0fxZiXsV9V6cGFJoB5qh/vZM86EMnYHrkTamNXy/6yVTIxRmwNZLhVRrPsBaOaThfOQm4lMw6TOzlqDmt4YBiTnF9oxC7iK8bsEf9SWoI8oeYayF2dtDZBo1SPrUR53+BDl0Xlvolx6eytKeXVEjhKs2kYmRN26WC622GHFwBfo2iIZDGwBSQP1uqr4P2DOvRPG3LNwOUkzcpbJG592YMLms9/YdQrpx1qR+wsyHlyTjICNDhcizRNrWjY6EKYRWR0NAkH3Wu8YkspuhH7qiiWyyGJNRCsppn/AfX9J+9LH8okkGV2h/OGHqlmWo6QaJGjLwTObUCj7JEml7l4eFspc8ThduSg8nTzFXhUAuygPxTKOZRt+bHF2S734vYKkbX2ARDPL1G3gbC3K7uqhEkLV3mpOyUz+57HQ0ukF0wCmTq+bZqD5gHwSA+CXmiVmMam/4y4Y+j08V+9hLwcMvTYPt2MxyXenYfLe+Cz4FL4prhUO0c26oOVSKVPPdNyU1k++jlHDm1S5CvvePoNGebq2I5DGgx8Sf/0n42Xv0=
     - main_version=2

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile 'com.sk89q.worldedit:worldedit-bukkit:6.1.5'
     compile 'org.librazy:NyaaUtilsLangChecker:1.0-SNAPSHOT'
     processor 'org.librazy:NyaaUtilsLangChecker:1.0-SNAPSHOT'
+    processor 'org.spigotmc:spigot-api:1.11.2-R0.1-SNAPSHOT'
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: 'java'
-apply plugin: 'maven-publish'
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'org.inferred.processors' version '1.2.11'
+}
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -26,6 +29,11 @@ repositories {
         name 'vault-repo'
         url 'http://nexus.hc.to/content/repositories/pub_releases'
     }
+
+    maven {
+        name 'nu-langchecker'
+        url 'https://raw.githubusercontent.com/Librazy/NyaaUtilsLangChecker/maven-repo'
+    }
 }
 
 dependencies {
@@ -34,6 +42,12 @@ dependencies {
     compile files('lib/LocketteProAPI.jar')
     compile files('lib/EssentialsX-2.0.1-468.jar')
     compile 'com.sk89q.worldedit:worldedit-bukkit:6.1.5'
+    compile 'org.librazy:NyaaUtilsLangChecker:1.0-SNAPSHOT'
+    processor 'org.librazy:NyaaUtilsLangChecker:1.0-SNAPSHOT'
+}
+
+compileJava {
+    options.compilerArgs += ["-Xplugin:NyaaUtilsLangAnnotationProcessor"]
 }
 
 publishing {

--- a/src/main/java/cat/nyaa/nyaautils/CommandHandler.java
+++ b/src/main/java/cat/nyaa/nyaautils/CommandHandler.java
@@ -362,7 +362,7 @@ public class CommandHandler extends CommandReceiver<NyaaUtils> {
         Player p = asPlayer(sender);
         String name = args.next().replace("§", "");
         if (plugin.cfg.renameCharacterLimit != 0 && ChatColor.stripColor(name).length() > NyaaUtils.instance.cfg.renameCharacterLimit) {
-            msg(p, "user.rename.name_too_long", name);
+            msg(p, "user.rename.name_too_long", name, NyaaUtils.instance.cfg.renameCharacterLimit);
             return;
         }
         for (String k : plugin.cfg.renameDisabledFormattingCodes) {

--- a/src/main/java/cat/nyaa/nyaautils/I18n.java
+++ b/src/main/java/cat/nyaa/nyaautils/I18n.java
@@ -2,6 +2,7 @@ package cat.nyaa.nyaautils;
 
 import cat.nyaa.utils.Internationalization;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.librazy.nyaautils_lang_checker.LangKey;
 
 public class I18n extends Internationalization {
     public static I18n instance = null;
@@ -25,7 +26,7 @@ public class I18n extends Internationalization {
         load();
     }
 
-    public static String format(String key, Object... args) {
+    public static String format(@LangKey String key, Object... args) {
         return instance.get(key, args);
     }
 }

--- a/src/main/java/cat/nyaa/nyaautils/commandwarpper/Teleport.java
+++ b/src/main/java/cat/nyaa/nyaautils/commandwarpper/Teleport.java
@@ -20,6 +20,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.permissions.PermissionAttachment;
+import org.librazy.nyaautils_lang_checker.LangKey;
 
 import java.text.DecimalFormat;
 import java.util.List;
@@ -233,7 +234,7 @@ public class Teleport implements Listener {
         return 0;
     }
 
-    private void msg(CommandSender target, String template, Object... args) {
+    private void msg(CommandSender target, @LangKey String template, Object... args) {
         target.sendMessage(I18n.format(template, args));
     }
 }

--- a/src/main/java/cat/nyaa/nyaautils/dropprotect/DropProtectMode.java
+++ b/src/main/java/cat/nyaa/nyaautils/dropprotect/DropProtectMode.java
@@ -1,5 +1,9 @@
 package cat.nyaa.nyaautils.dropprotect;
 
+import org.librazy.nyaautils_lang_checker.LangKey;
+import org.librazy.nyaautils_lang_checker.LangKeyType;
+
+@LangKey(type = LangKeyType.SUFFIX)
 public enum DropProtectMode {
     OFF,
     ON

--- a/src/main/java/cat/nyaa/nyaautils/exhibition/ExhibitionCommands.java
+++ b/src/main/java/cat/nyaa/nyaautils/exhibition/ExhibitionCommands.java
@@ -70,7 +70,7 @@ public class ExhibitionCommands extends CommandReceiver<NyaaUtils> {
         } else if (p.hasPermission("nu.exhibition.forceUnset")) {
             f.unset();
         } else {
-            msg(sender, "nu.exhibition.unset_protected");
+            msg(sender, "user.exhibition.unset_protected");
         }
     }
 
@@ -123,7 +123,7 @@ public class ExhibitionCommands extends CommandReceiver<NyaaUtils> {
                 }
             }
         } else {
-            msg(sender, "nu.exhibition.desc_protected");
+            msg(sender, "user.exhibition.desc_protected");
         }
     }
 }

--- a/src/main/java/cat/nyaa/nyaautils/lootprotect/LootProtectMode.java
+++ b/src/main/java/cat/nyaa/nyaautils/lootprotect/LootProtectMode.java
@@ -1,5 +1,9 @@
 package cat.nyaa.nyaautils.lootprotect;
 
+import org.librazy.nyaautils_lang_checker.LangKey;
+import org.librazy.nyaautils_lang_checker.LangKeyType;
+
+@LangKey(type = LangKeyType.SUFFIX)
 public enum LootProtectMode {
     OFF,
     MAX_DAMAGE,

--- a/src/main/java/cat/nyaa/nyaautils/mailbox/MailboxCommands.java
+++ b/src/main/java/cat/nyaa/nyaautils/mailbox/MailboxCommands.java
@@ -74,7 +74,7 @@ public class MailboxCommands extends CommandReceiver<NyaaUtils> {
                     if (b.getState() instanceof Chest) {
                         plugin.cfg.mailbox.updateNameMapping(id, player);
                         plugin.cfg.mailbox.updateLocationMapping(id, b.getLocation());
-                        msg(admin, "user.mailbox.admin.success");
+                        msg(admin, "user.mailbox.admin.success_set");
                         if (p.isOnline()) {
                             Player tmp = plugin.getServer().getPlayer(id);
                             if (tmp != null) {
@@ -83,7 +83,7 @@ public class MailboxCommands extends CommandReceiver<NyaaUtils> {
                         }
                         return;
                     }
-                    msg(admin, "user.mailbox.admin.fail");
+                    msg(admin, "user.mailbox.admin.fail_set");
                 });
         msg(admin, "user.mailbox.admin.right_click_set", player);
     }

--- a/src/main/java/cat/nyaa/nyaautils/realm/RealmType.java
+++ b/src/main/java/cat/nyaa/nyaautils/realm/RealmType.java
@@ -1,4 +1,7 @@
 package cat.nyaa.nyaautils.realm;
 
+import org.librazy.nyaautils_lang_checker.LangKey;
+import org.librazy.nyaautils_lang_checker.LangKeyType;
 
+@LangKey(type = LangKeyType.SUFFIX)
 public enum RealmType {PUBLIC, PRIVATE}

--- a/src/main/java/cat/nyaa/nyaautils/repair/RepairInstance.java
+++ b/src/main/java/cat/nyaa/nyaautils/repair/RepairInstance.java
@@ -4,9 +4,11 @@ import cat.nyaa.nyaautils.NyaaUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Repairable;
+import org.librazy.nyaautils_lang_checker.LangKey;
+import org.librazy.nyaautils_lang_checker.LangKeyType;
 
 public class RepairInstance {
-    public enum RepairStat {
+    @LangKey(type = LangKeyType.SUFFIX) public enum RepairStat {
         UNREPAIRABLE,
         UNREPAIRABLE_REPAIRED,
         UNREPAIRABLE_UNBREAKABLE,

--- a/src/main/java/cat/nyaa/utils/CommandReceiver.java
+++ b/src/main/java/cat/nyaa/utils/CommandReceiver.java
@@ -9,6 +9,8 @@ import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.librazy.nyaautils_lang_checker.LangKey;
+import org.librazy.nyaautils_lang_checker.LangKeyType;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -198,7 +200,7 @@ public abstract class CommandReceiver<T extends JavaPlugin> implements CommandEx
         } catch (NoItemInHandException ex) {
             msg(sender, ex.isOffHand ? "internal.error.no_item_offhand" : "internal.error.no_item_hand");
         } catch (BadCommandException ex) {
-            String msg = ex.getMessage();
+            @LangKey String msg = ex.getMessage();
             if (msg != null && !msg.equals("")) {
                 if (ex.objs == null) {
                     msg(sender, msg);
@@ -251,8 +253,8 @@ public abstract class CommandReceiver<T extends JavaPlugin> implements CommandEx
 
     public abstract String getHelpPrefix();
 
-    private String getHelpContent(String type, String... subkeys) {
-        String key = "manual";
+    private String getHelpContent(@LangKey(type = LangKeyType.SUFFIX, skipCheck = true) String type, String... subkeys) {
+        @LangKey String key = "manual";
         for (String s : subkeys) {
             if (s.length() > 0)
                 key += "." + s;
@@ -286,7 +288,7 @@ public abstract class CommandReceiver<T extends JavaPlugin> implements CommandEx
         }
     }
 
-    public void msg(CommandSender target, String template, Object... args) {
+    public void msg(CommandSender target, @LangKey String template, Object... args) {
         target.sendMessage(i18n.get(template, args));
     }
 

--- a/src/main/java/cat/nyaa/utils/Internationalization.java
+++ b/src/main/java/cat/nyaa/utils/Internationalization.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.librazy.nyaautils_lang_checker.LangKey;
 
 import java.io.File;
 import java.io.IOException;
@@ -129,7 +130,7 @@ public abstract class Internationalization {
     }
 
 
-    public String get(String key, Object... para) {
+    public String get(@LangKey String key, Object... para) {
         String val = map.get(key);
         if (val == null || val.startsWith("internal.")) val = internalMap.get(key);
         if (val == null) {

--- a/src/main/java/cat/nyaa/utils/Message.java
+++ b/src/main/java/cat/nyaa/utils/Message.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.librazy.nyaautils_lang_checker.LangKey;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -34,7 +35,7 @@ public final class Message {
         return this;
     }
 
-    public Message appendFormat(Internationalization i18n, String template, Object... obj) {
+    public Message appendFormat(Internationalization i18n, @LangKey String template, Object... obj) {
         return append(i18n.get(template, obj));
     }
 

--- a/src/main/resources/lang/en_US.yml
+++ b/src/main/resources/lang/en_US.yml
@@ -237,7 +237,7 @@ user:
     broadcast_disable: "Broadcast disabled"
     checkpoint_remove: "Checkpoint %s has been removed"
     checkpoint_not_found: "Checkpoint %s not found"
-    checkpoint_broadcast: "[%s] Player %s reache checkpoint %d, time [ %d min %.2fs ] "
+    checkpoint_broadcast: "[%s] Player %s reached checkpoint %d, time [ %d min %.2fs ] "
     checkpoint_info: "Checkpoint %d world: %s (%d, %d, %d) (%d, %d, %d)"
     select: "Please select a area first"
     checkpoint_conflict: "Area conflict with checkpoint %d"


### PR DESCRIPTION
And fixed some erroneous lang keys found by it.

**Examples (in my modified source for testing):**
```
C:\Users\Liqueur Librazy\Documents\Github\nyaautils\src\main\java\cat\nyaa\nyaautils\lootprotect\LootProtectMode.java:7: 警告: Key component suffix LANG_CHECKER not found in lang en_US.yml
public enum LootProtectMode {
       ^
C:\Users\Liqueur Librazy\Documents\Github\nyaautils\src\main\java\cat\nyaa\nyaautils\CommandHandler.java:229: 警告: Key prefix user.p.mode_ not found in lang en_US.yml
        p.sendMessage(I18n.format("user.p.mode_" + plugin.cfg.lootProtectMode.name()));
                                  ^
C:\Users\Liqueur Librazy\Documents\Github\nyaautils\src\main\java\cat\nyaa\nyaautils\CommandHandler.java:365: 警告: Corrupted key user.rename.name_too_long in en_US.yml: Name '%s' is too long! Should less than %d chars
            msg(p, "user.rename.name_too_long", name);
                   ^
C:\Users\Liqueur Librazy\Documents\Github\nyaautils\src\main\java\cat\nyaa\nyaautils\CommandHandler.java:370: 警告: Key nu.warn.blocked_format_codes not found in lang en_US.yml
                msg(p, "nu.warn.blocked_format_codes", "&" + k);
                       ^
```
**Integrating with idea:**

![image](https://cloud.githubusercontent.com/assets/2211542/25472680/ec9357b0-2b5e-11e7-8c92-db97132519f5.png)


![image](https://cloud.githubusercontent.com/assets/2211542/25472561/56ef2464-2b5e-11e7-8042-fd2f0efae115.png)
